### PR TITLE
Add chat UI with citation footnotes

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -31,3 +31,15 @@ def store_chunks(doc_id: str, filename: str, chunks: list[str]):
     conn.commit()
     conn.close()
 
+
+def get_chunk(doc_id: str, chunk_index: int) -> str | None:
+    conn = sqlite3.connect(DB_FILE)
+    c = conn.cursor()
+    c.execute(
+        "SELECT text FROM chunks WHERE doc_id = ? AND chunk_index = ?",
+        (doc_id, chunk_index),
+    )
+    row = c.fetchone()
+    conn.close()
+    return row[0] if row else None
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "next": "13.5.4",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "marked": "5.1.1"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -145,4 +145,6 @@ saved to a local SQLite database (`db.sqlite3`) before embeddings are stored in
 Chroma.
 Queries go through a conversational retrieval chain so follow-up questions can
 reference earlier answers. Pass the returned `chat_id` back to `/ask` to keep
-context across messages.
+context across messages. Answers now include a list of source chunks and the
+frontend renders them as clickable footnotes. Clicking a footnote calls the new
+`/chunk` endpoint to display the text snippet from the original PDF.


### PR DESCRIPTION
## Summary
- store `doc_id` in vector store metadata
- expose `/chunk` API to fetch source text for citations
- add chat UI with markdown rendering and clickable footnotes
- document new citation feature in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443bebaf7c8331a4baacd37e855e36