### PR TITLE
Fix Docker setup instructions

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -6,6 +6,7 @@ This guide describes how to start the PDF assistant and interact with it.
 
 - Docker and docker-compose installed
 - An OpenAI API key set in the environment as `OPENAI_API_KEY`
+- Docker daemon running (start Docker Desktop or use `colima start` on macOS)
 
 ## Starting the services
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   backend:
     build: ./backend

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,8 @@ Clone the repository and run:
 docker-compose up --build
 ```
 
+Make sure the Docker daemon is running (e.g. start Docker Desktop or run `colima start` on macOS) before executing the command.
+
 The backend will be available at http://localhost:8000 and the frontend at http://localhost:3000.
 
 Upload PDFs via the UI then ask questions about their content.


### PR DESCRIPTION
## Summary
- add note about starting Docker daemon in USAGE guide
- remind users in README to start Docker before running compose
- remove outdated version field from docker-compose

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684441572d2c8331bbd5bd94bf854b55