### PR TITLE
Fix langchain imports and module path

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -6,6 +6,7 @@ This guide describes how to start the PDF assistant and interact with it.
 
 - Docker and docker-compose installed
 - An OpenAI API key set in the environment as `OPENAI_API_KEY`
+- Docker daemon running (start Docker Desktop or use `colima start` on macOS)
 
 ## Starting the services
 
@@ -16,11 +17,15 @@ git clone <repo-url>
 cd novel-summarizer
 ```
 
-2. Build and start all containers:
+2. Create the directories used for volume mounts and start all containers:
 
 ```bash
+mkdir -p uploads chromadb
 docker-compose up --build
 ```
+
+If a `ModuleNotFoundError` for `langchain_community` appears, rebuild the
+containers to install the `langchain-community` package.
 
 The FastAPI backend will be running on [http://localhost:8000](http://localhost:8000) and the React frontend on [http://localhost:3000](http://localhost:3000).
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,19 +2,19 @@ from fastapi import FastAPI, UploadFile, File, HTTPException, BackgroundTasks, R
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain.embeddings import HuggingFaceEmbeddings
-from langchain.vectorstores import Chroma
-from langchain.llms import OpenAI
+from langchain_community.embeddings import HuggingFaceEmbeddings
+from langchain_community.vectorstores import Chroma
+from langchain_community.llms import OpenAI
 from langchain.chains import ConversationalRetrievalChain
 from langchain.memory import ConversationBufferMemory
-from langchain.callbacks import get_openai_callback
+from langchain_community.callbacks.manager import get_openai_callback
 import logging
 import time
 import os
 import shutil
 from pdfminer.high_level import extract_text
 import uuid
-from . import database
+import database
 
 UPLOAD_DIR = "uploads"
 DB_DIR = "chromadb"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,4 +7,5 @@ Pillow
 sentence-transformers
 chromadb
 langchain
+langchain-community
 openai

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   backend:
     build: ./backend

--- a/readme.md
+++ b/readme.md
@@ -131,11 +131,17 @@ Use (or adapt) this design plan as the blueprint for your project brief—ready 
 
 ## Getting Started
 
-Clone the repository and run:
+Clone the repository, ensure Docker is running, and create the directories used as volume mounts:
 
 ```bash
+mkdir -p uploads chromadb
 docker-compose up --build
 ```
+
+If you encounter a `ModuleNotFoundError` for `langchain_community`, rebuild the
+image to install the required `langchain-community` package.
+
+Make sure the Docker daemon is running (e.g. start Docker Desktop or run `colima start` on macOS) before executing the commands above.
 
 The backend will be available at http://localhost:8000 and the frontend at http://localhost:3000.
 


### PR DESCRIPTION
## Summary
- use `langchain_community` modules in `backend/main.py`
- import `database` as a top-level module instead of using a relative import

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker-compose build --no-cache` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684441572d2c8331bbd5bd94bf854b55